### PR TITLE
Explictely list the ASCII letters as allowed

### DIFF
--- a/src/Plugin/search_api/backend/SearchApiSolrBackend.php
+++ b/src/Plugin/search_api/backend/SearchApiSolrBackend.php
@@ -1001,7 +1001,7 @@ class SearchApiSolrBackend extends BackendPluginBase {
           // leading and trailing underscores (e.g. _version_) are reserved."
           // Field names starting with digits or underscores are already avoided
           // by our schema.
-          $name = $pref . '_' . preg_replace_callback('/([^\d\w_]{1})/',
+          $name = $pref . '_' . preg_replace_callback('/([^\da-zA-Z_]{1})/u',
             function ($matches) {
               // Convert non Java identifiers and '$' into byte-wise hexadecimal
               // values encapsulated by '_'.

--- a/src/Plugin/search_api/backend/SearchApiSolrBackend.php
+++ b/src/Plugin/search_api/backend/SearchApiSolrBackend.php
@@ -1001,7 +1001,7 @@ class SearchApiSolrBackend extends BackendPluginBase {
           // leading and trailing underscores (e.g. _version_) are reserved."
           // Field names starting with digits or underscores are already avoided
           // by our schema.
-          $name = $pref . '_' . preg_replace_callback('/([^\da-zA-Z_]{1})/u',
+          $name = $pref . '_' . preg_replace_callback('/([^\da-zA-Z_])/u',
             function ($matches) {
               // Convert non Java identifiers and '$' into byte-wise hexadecimal
               // values encapsulated by '_'.


### PR DESCRIPTION
We cannot rely on \w as it also matches the latin1 letters between 128 and 255 (e.g. Ã) which we would like to have encoded.
In addition we now match in Unicode mode so a Unicode character is replaced with a single hex string instead of one per byte.
