### PR TITLE
Drupal 8.6 prepends 'field_' to comment.

### DIFF
--- a/search_api_solr_defaults/search_api_solr_defaults.install
+++ b/search_api_solr_defaults/search_api_solr_defaults.install
@@ -16,7 +16,7 @@ function search_api_solr_defaults_requirements($phase) {
   if ($phase == 'install') {
     $node_types = NodeType::loadMultiple();
     $required_types = [
-      'article' => ['body', 'comment', 'field_tags', 'field_image'],
+      'article' => ['body', 'field_comment', 'field_tags', 'field_image'],
       'page' => ['body'],
     ];
 


### PR DESCRIPTION
when you create the article content type and add the comment field, the module breaks because drupal prepends 'field_' to the field name. There's no easy way to change this outside of hacking drupal core.