### PR TITLE
Issue #3054629: search-api-solr:get-server-config throws notice

### DIFF
--- a/src/Utility/CommandHelper.php
+++ b/src/Utility/CommandHelper.php
@@ -33,7 +33,8 @@ class CommandHelper extends \Drupal\search_api\Utility\CommandHelper {
   public function getServerConfigCommand($server_id, $file_name, $solr_version = NULL) {
     /** @var \Drupal\search_api_solr\Controller\SolrFieldTypeListBuilder $list_builder */
     $list_builder = $this->entityTypeManager->getListBuilder('solr_field_type');
-    $server = reset($this->loadServers([$server_id]));
+    $servers = $this->loadServers([$server_id]);
+    $server = reset($servers);
     if ($solr_version) {
       $config = $server->getBackendConfig();
       // Temporarily switch the Solr version but don't save!


### PR DESCRIPTION
Notice: Only variables should be passed by reference in web/modules/contrib/search_api_solr/src/Utility/CommandHelper.php on line 37

Fixes https://www.drupal.org/project/search_api_solr/issues/3054629