### PR TITLE
Issue  #3079051: Initialize $keys as two-dimenisonal

### DIFF
--- a/src/Utility/Utility.php
+++ b/src/Utility/Utility.php
@@ -200,7 +200,7 @@ class Utility {
       $snippets = [$snippets];
     }
 
-    $keys = [];
+    $keys = [[]];
 
     foreach ($snippets as $snippet) {
       if (preg_match_all('@\[HIGHLIGHT\](.+?)\[/HIGHLIGHT\]@', $snippet, $matches)) {


### PR DESCRIPTION
In case $keys remain emtpy, initializing it as a two-dimensional array prevents php-errors in further operations.