### PR TITLE
Issue #3089339: Fixed storing response body in the log message context

### DIFF
--- a/modules/search_api_solr_devel/src/Logging/SolariumRequestLogger.php
+++ b/modules/search_api_solr_devel/src/Logging/SolariumRequestLogger.php
@@ -82,7 +82,10 @@ class SolariumRequestLogger implements EventSubscriberInterface {
       $this->t('Received Solr response')
     );
 
-    $this->getLogger()->debug($response->getBody());
+    $this->getLogger()->debug(
+      '@solr_request_body',
+      ['@solr_request_body' => $response->getBody()]
+    );
     $this->showLoggerHint();
   }
 


### PR DESCRIPTION
See https://www.drupal.org/project/search_api_solr/issues/3089339

## Problem/Motivation

When debugging is enabled trough the search_api_solr_devel module, every search response body is stored as the logging message. This causes, when accessing the debug information through the dblog interface, running the t() function on that body.

This floods the locale tables with untranslatable content. A fatal error is triggered if the response body is too large to handle by the locales_source table.

## Proposed resolution

Use a placeholder as message and pass the response body as the logging message context.

modules/search_api_solr_devel/src/Logging/SolariumRequestLogger.php:85

```php
    $this->getLogger()->debug(
      '@solr_request_body',
      ['@solr_request_body' => $response->getBody()]
    );
```