### PR TITLE
Treat 0 code as unexpected, add exception message

### DIFF
--- a/src/SolrConnector/SolrConnectorPluginBase.php
+++ b/src/SolrConnector/SolrConnectorPluginBase.php
@@ -1003,7 +1003,7 @@ abstract class SolrConnectorPluginBase extends ConfigurablePluginBase implements
       default:
         $description = 'unreachable or returned unexpected response code';
     }
-    throw new SearchApiSolrException(sprintf('Solr endpoint %s %s (response code: %d, exception: "%s"). %s', $this->getEndpointUri($endpoint), $description, $response_code, $e->getMessage(), $body), $response_code, $e);
+    throw new SearchApiSolrException(sprintf('Solr endpoint %s %s (code: %d, message: %s). %s', $this->getEndpointUri($endpoint), $description, $response_code, $e->getMessage(), $body), $response_code, $e);
   }
 
   /**

--- a/src/SolrConnector/SolrConnectorPluginBase.php
+++ b/src/SolrConnector/SolrConnectorPluginBase.php
@@ -997,14 +997,13 @@ abstract class SolrConnectorPluginBase extends ConfigurablePluginBase implements
         break;
 
       case '500': // Internal Server Error.
-      case '0':
         $description = 'internal Solr server error';
         break;
 
       default:
         $description = 'unreachable or returned unexpected response code';
     }
-    throw new SearchApiSolrException(sprintf('Solr endpoint %s %s (%d). %s', $this->getEndpointUri($endpoint), $description, $response_code, $body), $response_code, $e);
+    throw new SearchApiSolrException(sprintf('Solr endpoint %s %s (response code: %d, exception: "%s"). %s', $this->getEndpointUri($endpoint), $description, $response_code, $e->getMessage(), $body), $response_code, $e);
   }
 
   /**


### PR DESCRIPTION
When Solr is not so quick, Solarium library sometimes returns HTTP exception with code "0" and message like this:
```
Solr HTTP error: HTTP request failed, Resolving timed out after 5000 milliseconds
```

But in the search_api_solr module it is treated as "internal Solr server error" because of this code part:
```php
      case '500': // Internal Server Error.
      case '0':
        $description = 'internal Solr server error';
        break;
```
Looking at that error, I spend a lot of time to figure out the real source of the problem, because in Solr backend logs I didn't see any Internal Server Error with code 500, and in Drupal logs there are no info about timeout error, I see only this text in Drupal watchdog record:
```
Drupal\\search_api_solr\\SearchApiSolrException while maintaining Solr server Solr Server: Solr endpoint https://solr:30001/ internal Solr server error (0). in Drupal\\search_api_solr\\SolrConnector\\SolrConnectorPluginBase->handleHttpException() (line 1010 of web/modules/contrib/search_api_solr/src/SolrConnector/SolrConnectorPluginBase.php).
```
From which it's impossible to understand that this is a timeout problem.

So, in fact the code '0' is not an internal server error, but in most cases this is a timeout or some other connection problems.

I suggest to solve this issue via excluding '0' from "Internal Server Error" section, to process it as 'unreachable or returned unexpected response code', or, alternatively, add separate section for '0' error code.

Also I added underlying exception message to SearchApiSolrException text, to show real exception text in Drupal logs for easier investigating source of problems.

Please review my MR and comment if something must be reworked.