### PR TITLE
Index zxx (LANGUAGE_NOT_APPLICABLE) as und (LANGUAGE_NOT_SPECIFIED)

### DIFF
--- a/src/Plugin/search_api/backend/SearchApiSolrBackend.php
+++ b/src/Plugin/search_api/backend/SearchApiSolrBackend.php
@@ -1141,6 +1141,7 @@ class SearchApiSolrBackend extends BackendPluginBase implements SolrBackendInter
       $language_id = $item->getLanguage();
       if ($language_id === LanguageInterface::LANGCODE_NOT_APPLICABLE) {
         $language_id = LanguageInterface::LANGCODE_NOT_SPECIFIED;
+        $item->setLanguage(LanguageInterface::LANGCODE_NOT_SPECIFIED);
       }
       $field_names = $this->getLanguageSpecificSolrFieldNames($language_id, $index);
       $boost_terms = [];

--- a/tests/src/Kernel/SearchApiSolrTest.php
+++ b/tests/src/Kernel/SearchApiSolrTest.php
@@ -1260,7 +1260,8 @@ class SearchApiSolrTest extends SolrBackendTestBase {
     $expected_results = [
       1 => 'en',
       2 => 'en',
-      7 => LanguageInterface::LANGCODE_NOT_SPECIFIED
+      7 => LanguageInterface::LANGCODE_NOT_SPECIFIED,
+      8 => LanguageInterface::LANGCODE_NOT_SPECIFIED,
     ];
     $this->assertResults($expected_results, $results, 'Search content and unspecified language for "gene".');
 
@@ -1277,7 +1278,8 @@ class SearchApiSolrTest extends SolrBackendTestBase {
       4 => 'de',
       5 => 'de-at',
       6 => 'de-at',
-      7 => LanguageInterface::LANGCODE_NOT_SPECIFIED
+      7 => LanguageInterface::LANGCODE_NOT_SPECIFIED,
+      8 => LanguageInterface::LANGCODE_NOT_SPECIFIED,
     ];
     $this->assertResults($expected_results, $results, 'Search all and unspecified languages for "gene".');
 


### PR DESCRIPTION
See https://www.drupal.org/project/search_api_solr/issues/3197168