### PR TITLE
Remove collated_* field for Solr 8.11

### DIFF
--- a/jump-start/solr8/config-set/schema_extra_fields.xml
+++ b/jump-start/solr8/config-set/schema_extra_fields.xml
@@ -4,49 +4,42 @@
 <dynamicField name="tom_X3b_ar_*" type="text_ar" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="true" />
 <dynamicField name="tus_X3b_ar_*" type="text_unstemmed_ar" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="false" />
 <dynamicField name="tum_X3b_ar_*" type="text_unstemmed_ar" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="false" />
-<dynamicField name="sort_X3b_ar_*" type="collated_ar" stored="false" indexed="false" docValues="true" useDocValuesAsStored="false" />
 <dynamicField name="ts_X3b_bg_*" type="text_bg" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="false" />
 <dynamicField name="tm_X3b_bg_*" type="text_bg" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="false" />
 <dynamicField name="tos_X3b_bg_*" type="text_bg" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="true" />
 <dynamicField name="tom_X3b_bg_*" type="text_bg" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="true" />
 <dynamicField name="tus_X3b_bg_*" type="text_unstemmed_bg" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="false" />
 <dynamicField name="tum_X3b_bg_*" type="text_unstemmed_bg" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="false" />
-<dynamicField name="sort_X3b_bg_*" type="collated_bg" stored="false" indexed="false" docValues="true" useDocValuesAsStored="false" />
 <dynamicField name="ts_X3b_ca_*" type="text_ca" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="false" />
 <dynamicField name="tm_X3b_ca_*" type="text_ca" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="false" />
 <dynamicField name="tos_X3b_ca_*" type="text_ca" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="true" />
 <dynamicField name="tom_X3b_ca_*" type="text_ca" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="true" />
 <dynamicField name="tus_X3b_ca_*" type="text_unstemmed_ca" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="false" />
 <dynamicField name="tum_X3b_ca_*" type="text_unstemmed_ca" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="false" />
-<dynamicField name="sort_X3b_ca_*" type="collated_ca" stored="false" indexed="false" docValues="true" useDocValuesAsStored="false" />
 <dynamicField name="ts_X3b_hr_*" type="text_hr" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="false" />
 <dynamicField name="tm_X3b_hr_*" type="text_hr" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="false" />
 <dynamicField name="tos_X3b_hr_*" type="text_hr" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="true" />
 <dynamicField name="tom_X3b_hr_*" type="text_hr" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="true" />
 <dynamicField name="tus_X3b_hr_*" type="text_unstemmed_hr" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="false" />
 <dynamicField name="tum_X3b_hr_*" type="text_unstemmed_hr" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="false" />
-<dynamicField name="sort_X3b_hr_*" type="collated_hr" stored="false" indexed="false" docValues="true" useDocValuesAsStored="false" />
 <dynamicField name="ts_X3b_cs_*" type="text_cs" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="false" />
 <dynamicField name="tm_X3b_cs_*" type="text_cs" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="false" />
 <dynamicField name="tos_X3b_cs_*" type="text_cs" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="true" />
 <dynamicField name="tom_X3b_cs_*" type="text_cs" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="true" />
 <dynamicField name="tus_X3b_cs_*" type="text_unstemmed_cs" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="false" />
 <dynamicField name="tum_X3b_cs_*" type="text_unstemmed_cs" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="false" />
-<dynamicField name="sort_X3b_cs_*" type="collated_cs" stored="false" indexed="false" docValues="true" useDocValuesAsStored="false" />
 <dynamicField name="ts_X3b_da_*" type="text_da" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="false" />
 <dynamicField name="tm_X3b_da_*" type="text_da" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="false" />
 <dynamicField name="tos_X3b_da_*" type="text_da" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="true" />
 <dynamicField name="tom_X3b_da_*" type="text_da" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="true" />
 <dynamicField name="tus_X3b_da_*" type="text_unstemmed_da" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="false" />
 <dynamicField name="tum_X3b_da_*" type="text_unstemmed_da" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="false" />
-<dynamicField name="sort_X3b_da_*" type="collated_da" stored="false" indexed="false" docValues="true" useDocValuesAsStored="false" />
 <dynamicField name="ts_X3b_nl_*" type="text_nl" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="false" />
 <dynamicField name="tm_X3b_nl_*" type="text_nl" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="false" />
 <dynamicField name="tos_X3b_nl_*" type="text_nl" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="true" />
 <dynamicField name="tom_X3b_nl_*" type="text_nl" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="true" />
 <dynamicField name="tus_X3b_nl_*" type="text_unstemmed_nl" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="false" />
 <dynamicField name="tum_X3b_nl_*" type="text_unstemmed_nl" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="false" />
-<dynamicField name="sort_X3b_nl_*" type="collated_nl" stored="false" indexed="false" docValues="true" useDocValuesAsStored="false" />
 <dynamicField name="tcedgestrings_X3b_und_*" type="text_edgenstring" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="false" />
 <dynamicField name="tcedgestrings_*" type="text_edgenstring" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="false" />
 <dynamicField name="tcedgestringm_X3b_und_*" type="text_edgenstring" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="false" />
@@ -77,21 +70,18 @@
 <dynamicField name="tom_X3b_en_*" type="text_en" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="true" />
 <dynamicField name="tus_X3b_en_*" type="text_unstemmed_en" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="false" />
 <dynamicField name="tum_X3b_en_*" type="text_unstemmed_en" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="false" />
-<dynamicField name="sort_X3b_en_*" type="collated_en" stored="false" indexed="false" docValues="true" useDocValuesAsStored="false" />
 <dynamicField name="ts_X3b_fi_*" type="text_fi" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="false" />
 <dynamicField name="tm_X3b_fi_*" type="text_fi" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="false" />
 <dynamicField name="tos_X3b_fi_*" type="text_fi" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="true" />
 <dynamicField name="tom_X3b_fi_*" type="text_fi" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="true" />
 <dynamicField name="tus_X3b_fi_*" type="text_unstemmed_fi" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="false" />
 <dynamicField name="tum_X3b_fi_*" type="text_unstemmed_fi" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="false" />
-<dynamicField name="sort_X3b_fi_*" type="collated_fi" stored="false" indexed="false" docValues="true" useDocValuesAsStored="false" />
 <dynamicField name="ts_X3b_fr_*" type="text_fr" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="false" />
 <dynamicField name="tm_X3b_fr_*" type="text_fr" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="false" />
 <dynamicField name="tos_X3b_fr_*" type="text_fr" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="true" />
 <dynamicField name="tom_X3b_fr_*" type="text_fr" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="true" />
 <dynamicField name="tus_X3b_fr_*" type="text_unstemmed_fr" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="false" />
 <dynamicField name="tum_X3b_fr_*" type="text_unstemmed_fr" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="false" />
-<dynamicField name="sort_X3b_fr_*" type="collated_fr" stored="false" indexed="false" docValues="true" useDocValuesAsStored="false" />
 <dynamicField name="tcphonetics_X3b_und_*" type="text_phonetic_und" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="false" />
 <dynamicField name="tcphonetics_*" type="text_phonetic_und" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="false" />
 <dynamicField name="tcphoneticm_X3b_und_*" type="text_phonetic_und" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="false" />
@@ -176,49 +166,42 @@
 <dynamicField name="tom_X3b_de_*" type="text_de" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="true" />
 <dynamicField name="tus_X3b_de_*" type="text_unstemmed_de" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="false" />
 <dynamicField name="tum_X3b_de_*" type="text_unstemmed_de" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="false" />
-<dynamicField name="sort_X3b_de_*" type="collated_de" stored="false" indexed="false" docValues="true" useDocValuesAsStored="false" />
 <dynamicField name="ts_X3b_el_*" type="text_el" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="false" />
 <dynamicField name="tm_X3b_el_*" type="text_el" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="false" />
 <dynamicField name="tos_X3b_el_*" type="text_el" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="true" />
 <dynamicField name="tom_X3b_el_*" type="text_el" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="true" />
 <dynamicField name="tus_X3b_el_*" type="text_unstemmed_el" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="false" />
 <dynamicField name="tum_X3b_el_*" type="text_unstemmed_el" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="false" />
-<dynamicField name="sort_X3b_el_*" type="collated_el" stored="false" indexed="false" docValues="true" useDocValuesAsStored="false" />
 <dynamicField name="ts_X3b_hi_*" type="text_hi" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="false" />
 <dynamicField name="tm_X3b_hi_*" type="text_hi" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="false" />
 <dynamicField name="tos_X3b_hi_*" type="text_hi" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="true" />
 <dynamicField name="tom_X3b_hi_*" type="text_hi" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="true" />
 <dynamicField name="tus_X3b_hi_*" type="text_unstemmed_hi" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="false" />
 <dynamicField name="tum_X3b_hi_*" type="text_unstemmed_hi" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="false" />
-<dynamicField name="sort_X3b_hi_*" type="collated_hi" stored="false" indexed="false" docValues="true" useDocValuesAsStored="false" />
 <dynamicField name="ts_X3b_hu_*" type="text_hu" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="false" />
 <dynamicField name="tm_X3b_hu_*" type="text_hu" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="false" />
 <dynamicField name="tos_X3b_hu_*" type="text_hu" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="true" />
 <dynamicField name="tom_X3b_hu_*" type="text_hu" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="true" />
 <dynamicField name="tus_X3b_hu_*" type="text_unstemmed_hu" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="false" />
 <dynamicField name="tum_X3b_hu_*" type="text_unstemmed_hu" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="false" />
-<dynamicField name="sort_X3b_hu_*" type="collated_hu" stored="false" indexed="false" docValues="true" useDocValuesAsStored="false" />
 <dynamicField name="ts_X3b_id_*" type="text_id" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="false" />
 <dynamicField name="tm_X3b_id_*" type="text_id" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="false" />
 <dynamicField name="tos_X3b_id_*" type="text_id" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="true" />
 <dynamicField name="tom_X3b_id_*" type="text_id" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="true" />
 <dynamicField name="tus_X3b_id_*" type="text_unstemmed_id" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="false" />
 <dynamicField name="tum_X3b_id_*" type="text_unstemmed_id" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="false" />
-<dynamicField name="sort_X3b_id_*" type="collated_id" stored="false" indexed="false" docValues="true" useDocValuesAsStored="false" />
 <dynamicField name="ts_X3b_ga_*" type="text_ga" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="false" />
 <dynamicField name="tm_X3b_ga_*" type="text_ga" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="false" />
 <dynamicField name="tos_X3b_ga_*" type="text_ga" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="true" />
 <dynamicField name="tom_X3b_ga_*" type="text_ga" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="true" />
 <dynamicField name="tus_X3b_ga_*" type="text_unstemmed_ga" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="false" />
 <dynamicField name="tum_X3b_ga_*" type="text_unstemmed_ga" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="false" />
-<dynamicField name="sort_X3b_ga_*" type="collated_ga" stored="false" indexed="false" docValues="true" useDocValuesAsStored="false" />
 <dynamicField name="ts_X3b_it_*" type="text_it" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="false" />
 <dynamicField name="tm_X3b_it_*" type="text_it" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="false" />
 <dynamicField name="tos_X3b_it_*" type="text_it" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="true" />
 <dynamicField name="tom_X3b_it_*" type="text_it" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="true" />
 <dynamicField name="tus_X3b_it_*" type="text_unstemmed_it" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="false" />
 <dynamicField name="tum_X3b_it_*" type="text_unstemmed_it" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="false" />
-<dynamicField name="sort_X3b_it_*" type="collated_it" stored="false" indexed="false" docValues="true" useDocValuesAsStored="false" />
 <dynamicField name="ts_X3b_ja_*" type="text_ja" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="false" />
 <dynamicField name="tm_X3b_ja_*" type="text_ja" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="false" />
 <dynamicField name="tos_X3b_ja_*" type="text_ja" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="true" />
@@ -226,7 +209,6 @@
 <dynamicField name="tus_X3b_ja_*" type="text_unstemmed_ja" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="false" />
 <dynamicField name="tum_X3b_ja_*" type="text_unstemmed_ja" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="false" />
 <dynamicField name="spellcheck_ja*" type="text_spell_ja" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="true" />
-<dynamicField name="sort_X3b_ja_*" type="collated_ja" stored="false" indexed="false" docValues="true" useDocValuesAsStored="false" />
 <dynamicField name="ts_X3b_und_*" type="text_und" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="false" />
 <dynamicField name="ts_*" type="text_und" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="false" />
 <dynamicField name="tm_X3b_und_*" type="text_und" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="false" />
@@ -241,15 +223,12 @@
 <dynamicField name="tum_*" type="text_und" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="false" />
 <dynamicField name="spellcheck_und*" type="text_spell_und" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="true" />
 <dynamicField name="spellcheck_*" type="text_spell_und" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="true" />
-<dynamicField name="sort_X3b_und_*" type="collated_und" stored="false" indexed="false" docValues="true" useDocValuesAsStored="false" />
-<dynamicField name="sort_*" type="collated_und" stored="false" indexed="false" docValues="true" useDocValuesAsStored="false" />
 <dynamicField name="ts_X3b_lv_*" type="text_lv" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="false" />
 <dynamicField name="tm_X3b_lv_*" type="text_lv" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="false" />
 <dynamicField name="tos_X3b_lv_*" type="text_lv" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="true" />
 <dynamicField name="tom_X3b_lv_*" type="text_lv" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="true" />
 <dynamicField name="tus_X3b_lv_*" type="text_unstemmed_lv" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="false" />
 <dynamicField name="tum_X3b_lv_*" type="text_unstemmed_lv" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="false" />
-<dynamicField name="sort_X3b_lv_*" type="collated_lv" stored="false" indexed="false" docValues="true" useDocValuesAsStored="false" />
 <dynamicField name="tcngramstrings_X3b_und_*" type="text_ngramstring" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="false" />
 <dynamicField name="tcngramstrings_*" type="text_ngramstring" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="false" />
 <dynamicField name="tcngramstringm_X3b_und_*" type="text_ngramstring" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="false" />
@@ -280,63 +259,54 @@
 <dynamicField name="tom_X3b_nb_*" type="text_nb" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="true" />
 <dynamicField name="tus_X3b_nb_*" type="text_unstemmed_nb" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="false" />
 <dynamicField name="tum_X3b_nb_*" type="text_unstemmed_nb" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="false" />
-<dynamicField name="sort_X3b_nb_*" type="collated_nb" stored="false" indexed="false" docValues="true" useDocValuesAsStored="false" />
 <dynamicField name="ts_X3b_nn_*" type="text_nn" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="false" />
 <dynamicField name="tm_X3b_nn_*" type="text_nn" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="false" />
 <dynamicField name="tos_X3b_nn_*" type="text_nn" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="true" />
 <dynamicField name="tom_X3b_nn_*" type="text_nn" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="true" />
 <dynamicField name="tus_X3b_nn_*" type="text_unstemmed_nn" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="false" />
 <dynamicField name="tum_X3b_nn_*" type="text_unstemmed_nn" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="false" />
-<dynamicField name="sort_X3b_nn_*" type="collated_nn" stored="false" indexed="false" docValues="true" useDocValuesAsStored="false" />
 <dynamicField name="ts_X3b_fa_*" type="text_fa" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="false" />
 <dynamicField name="tm_X3b_fa_*" type="text_fa" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="false" />
 <dynamicField name="tos_X3b_fa_*" type="text_fa" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="true" />
 <dynamicField name="tom_X3b_fa_*" type="text_fa" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="true" />
 <dynamicField name="tus_X3b_fa_*" type="text_unstemmed_fa" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="false" />
 <dynamicField name="tum_X3b_fa_*" type="text_unstemmed_fa" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="false" />
-<dynamicField name="sort_X3b_fa_*" type="collated_fa" stored="false" indexed="false" docValues="true" useDocValuesAsStored="false" />
 <dynamicField name="ts_X3b_pl_*" type="text_pl" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="false" />
 <dynamicField name="tm_X3b_pl_*" type="text_pl" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="false" />
 <dynamicField name="tos_X3b_pl_*" type="text_pl" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="true" />
 <dynamicField name="tom_X3b_pl_*" type="text_pl" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="true" />
 <dynamicField name="tus_X3b_pl_*" type="text_unstemmed_pl" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="false" />
 <dynamicField name="tum_X3b_pl_*" type="text_unstemmed_pl" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="false" />
-<dynamicField name="sort_X3b_pl_*" type="collated_pl" stored="false" indexed="false" docValues="true" useDocValuesAsStored="false" />
 <dynamicField name="ts_X3b_pt_X2d_br_*" type="text_pt_br" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="false" />
 <dynamicField name="tm_X3b_pt_X2d_br_*" type="text_pt_br" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="false" />
 <dynamicField name="tos_X3b_pt_X2d_br_*" type="text_pt_br" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="true" />
 <dynamicField name="tom_X3b_pt_X2d_br_*" type="text_pt_br" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="true" />
 <dynamicField name="tus_X3b_pt_X2d_br_*" type="text_unstemmed_pt_br" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="false" />
 <dynamicField name="tum_X3b_pt_X2d_br_*" type="text_unstemmed_pt_br" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="false" />
-<dynamicField name="sort_X3b_pt_X2d_br_*" type="collated_pt_br" stored="false" indexed="false" docValues="true" useDocValuesAsStored="false" />
 <dynamicField name="ts_X3b_pt_X2d_pt_*" type="text_pt_pt" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="false" />
 <dynamicField name="tm_X3b_pt_X2d_pt_*" type="text_pt_pt" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="false" />
 <dynamicField name="tos_X3b_pt_X2d_pt_*" type="text_pt_pt" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="true" />
 <dynamicField name="tom_X3b_pt_X2d_pt_*" type="text_pt_pt" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="true" />
 <dynamicField name="tus_X3b_pt_X2d_pt_*" type="text_unstemmed_pt_pt" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="false" />
 <dynamicField name="tum_X3b_pt_X2d_pt_*" type="text_unstemmed_pt_pt" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="false" />
-<dynamicField name="sort_X3b_pt_X2d_pt_*" type="collated_pt_pt" stored="false" indexed="false" docValues="true" useDocValuesAsStored="false" />
 <dynamicField name="ts_X3b_ro_*" type="text_ro" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="false" />
 <dynamicField name="tm_X3b_ro_*" type="text_ro" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="false" />
 <dynamicField name="tos_X3b_ro_*" type="text_ro" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="true" />
 <dynamicField name="tom_X3b_ro_*" type="text_ro" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="true" />
 <dynamicField name="tus_X3b_ro_*" type="text_unstemmed_ro" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="false" />
 <dynamicField name="tum_X3b_ro_*" type="text_unstemmed_ro" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="false" />
-<dynamicField name="sort_X3b_ro_*" type="collated_ro" stored="false" indexed="false" docValues="true" useDocValuesAsStored="false" />
 <dynamicField name="ts_X3b_ru_*" type="text_ru" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="false" />
 <dynamicField name="tm_X3b_ru_*" type="text_ru" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="false" />
 <dynamicField name="tos_X3b_ru_*" type="text_ru" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="true" />
 <dynamicField name="tom_X3b_ru_*" type="text_ru" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="true" />
 <dynamicField name="tus_X3b_ru_*" type="text_unstemmed_ru" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="false" />
 <dynamicField name="tum_X3b_ru_*" type="text_unstemmed_ru" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="false" />
-<dynamicField name="sort_X3b_ru_*" type="collated_ru" stored="false" indexed="false" docValues="true" useDocValuesAsStored="false" />
 <dynamicField name="ts_X3b_sr_*" type="text_sr" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="false" />
 <dynamicField name="tm_X3b_sr_*" type="text_sr" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="false" />
 <dynamicField name="tos_X3b_sr_*" type="text_sr" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="true" />
 <dynamicField name="tom_X3b_sr_*" type="text_sr" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="true" />
 <dynamicField name="tus_X3b_sr_*" type="text_unstemmed_sr" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="false" />
 <dynamicField name="tum_X3b_sr_*" type="text_unstemmed_sr" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="false" />
-<dynamicField name="sort_X3b_sr_*" type="collated_sr" stored="false" indexed="false" docValues="true" useDocValuesAsStored="false" />
 <dynamicField name="ts_X3b_zh_X2d_hans_*" type="text_zh_hans" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="false" />
 <dynamicField name="tm_X3b_zh_X2d_hans_*" type="text_zh_hans" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="false" />
 <dynamicField name="tos_X3b_zh_X2d_hans_*" type="text_zh_hans" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="true" />
@@ -344,28 +314,24 @@
 <dynamicField name="tus_X3b_zh_X2d_hans_*" type="text_unstemmed_zh_hans" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="false" />
 <dynamicField name="tum_X3b_zh_X2d_hans_*" type="text_unstemmed_zh_hans" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="false" />
 <dynamicField name="spellcheck_zh_hans*" type="text_spell_zh_hans" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="true" />
-<dynamicField name="sort_X3b_zh_X2d_hans_*" type="collated_zh_hans" stored="false" indexed="false" docValues="true" useDocValuesAsStored="false" />
 <dynamicField name="ts_X3b_sk_*" type="text_sk" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="false" />
 <dynamicField name="tm_X3b_sk_*" type="text_sk" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="false" />
 <dynamicField name="tos_X3b_sk_*" type="text_sk" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="true" />
 <dynamicField name="tom_X3b_sk_*" type="text_sk" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="true" />
 <dynamicField name="tus_X3b_sk_*" type="text_unstemmed_sk" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="false" />
 <dynamicField name="tum_X3b_sk_*" type="text_unstemmed_sk" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="false" />
-<dynamicField name="sort_X3b_sk_*" type="collated_sk" stored="false" indexed="false" docValues="true" useDocValuesAsStored="false" />
 <dynamicField name="ts_X3b_es_*" type="text_es" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="false" />
 <dynamicField name="tm_X3b_es_*" type="text_es" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="false" />
 <dynamicField name="tos_X3b_es_*" type="text_es" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="true" />
 <dynamicField name="tom_X3b_es_*" type="text_es" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="true" />
 <dynamicField name="tus_X3b_es_*" type="text_unstemmed_es" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="false" />
 <dynamicField name="tum_X3b_es_*" type="text_unstemmed_es" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="false" />
-<dynamicField name="sort_X3b_es_*" type="collated_es" stored="false" indexed="false" docValues="true" useDocValuesAsStored="false" />
 <dynamicField name="ts_X3b_sv_*" type="text_sv" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="false" />
 <dynamicField name="tm_X3b_sv_*" type="text_sv" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="false" />
 <dynamicField name="tos_X3b_sv_*" type="text_sv" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="true" />
 <dynamicField name="tom_X3b_sv_*" type="text_sv" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="true" />
 <dynamicField name="tus_X3b_sv_*" type="text_unstemmed_sv" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="false" />
 <dynamicField name="tum_X3b_sv_*" type="text_unstemmed_sv" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="false" />
-<dynamicField name="sort_X3b_sv_*" type="collated_sv" stored="false" indexed="false" docValues="true" useDocValuesAsStored="false" />
 <dynamicField name="ts_X3b_th_*" type="text_th" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="false" />
 <dynamicField name="tm_X3b_th_*" type="text_th" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="false" />
 <dynamicField name="tos_X3b_th_*" type="text_th" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="true" />
@@ -373,7 +339,6 @@
 <dynamicField name="tus_X3b_th_*" type="text_th" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="false" />
 <dynamicField name="tum_X3b_th_*" type="text_th" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="false" />
 <dynamicField name="spellcheck_th*" type="text_spell_th" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="true" />
-<dynamicField name="sort_X3b_th_*" type="collated_th" stored="false" indexed="false" docValues="true" useDocValuesAsStored="false" />
 <dynamicField name="ts_X3b_zh_X2d_hant_*" type="text_zh_hant" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="false" />
 <dynamicField name="tm_X3b_zh_X2d_hant_*" type="text_zh_hant" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="false" />
 <dynamicField name="tos_X3b_zh_X2d_hant_*" type="text_zh_hant" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="true" />
@@ -381,7 +346,6 @@
 <dynamicField name="tus_X3b_zh_X2d_hant_*" type="text_zh_hant" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="false" />
 <dynamicField name="tum_X3b_zh_X2d_hant_*" type="text_zh_hant" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="false" />
 <dynamicField name="spellcheck_zh_hant*" type="text_spell_zh_hant" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="true" />
-<dynamicField name="sort_X3b_zh_X2d_hant_*" type="collated_zh_hant" stored="false" indexed="false" docValues="true" useDocValuesAsStored="false" />
 <dynamicField name="ts_X3b_tr_*" type="text_tr" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="false" />
 <dynamicField name="tm_X3b_tr_*" type="text_tr" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="false" />
 <dynamicField name="tos_X3b_tr_*" type="text_tr" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="true" />
@@ -389,11 +353,9 @@
 <dynamicField name="tus_X3b_tr_*" type="text_unstemmed_tr" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="false" />
 <dynamicField name="tum_X3b_tr_*" type="text_unstemmed_tr" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="false" />
 <dynamicField name="spellcheck_tr*" type="text_spell_tr" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="true" />
-<dynamicField name="sort_X3b_tr_*" type="collated_tr" stored="false" indexed="false" docValues="true" useDocValuesAsStored="false" />
 <dynamicField name="ts_X3b_uk_*" type="text_uk" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="false" />
 <dynamicField name="tm_X3b_uk_*" type="text_uk" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="false" />
 <dynamicField name="tos_X3b_uk_*" type="text_uk" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="true" />
 <dynamicField name="tom_X3b_uk_*" type="text_uk" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="true" />
 <dynamicField name="tus_X3b_uk_*" type="text_unstemmed_uk" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="false" />
 <dynamicField name="tum_X3b_uk_*" type="text_unstemmed_uk" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="false" />
-<dynamicField name="sort_X3b_uk_*" type="collated_uk" stored="false" indexed="false" docValues="true" useDocValuesAsStored="false" />

--- a/jump-start/solr8/config-set/schema_extra_types.xml
+++ b/jump-start/solr8/config-set/schema_extra_types.xml
@@ -20,11 +20,6 @@
   </analyzer>
 </fieldType>
 <!--
-  Arabic Text Field collated
-  7.0.0
--->
-<fieldType name="collated_ar" class="solr.ICUCollationField" locale="ar" strength="primary" caseLevel="false"/>
-<!--
   Arabic Text Field unstemmed
   7.0.0
 -->
@@ -66,11 +61,6 @@
     <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
   </analyzer>
 </fieldType>
-<!--
-  Bulgarian Text Field collated
-  7.0.0
--->
-<fieldType name="collated_bg" class="solr.ICUCollationField" locale="bg" strength="primary" caseLevel="false"/>
 <!--
   Bulgarian Text Field unstemmed
   7.0.0
@@ -118,11 +108,6 @@
     <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
   </analyzer>
 </fieldType>
-<!--
-  Catalan Text Field collated
-  7.0.0
--->
-<fieldType name="collated_ca" class="solr.ICUCollationField" locale="ca" strength="primary" caseLevel="false"/>
 <!--
   Catalan Text Field unstemmed
   7.0.0
@@ -174,11 +159,6 @@
   </analyzer>
 </fieldType>
 <!--
-  Croatian Text Field collated
-  7.0.0
--->
-<fieldType name="collated_hr" class="solr.ICUCollationField" locale="hr" strength="primary" caseLevel="false"/>
-<!--
   Croatian Text Field unstemmed
   7.0.0
 -->
@@ -229,11 +209,6 @@
     <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
   </analyzer>
 </fieldType>
-<!--
-  Czech Text Field collated
-  7.0.0
--->
-<fieldType name="collated_cs" class="solr.ICUCollationField" locale="cs" strength="primary" caseLevel="false"/>
 <!--
   Czech Text Field unstemmed
   7.0.0
@@ -287,11 +262,6 @@
   </analyzer>
 </fieldType>
 <!--
-  Danish Text Field collated
-  7.0.0
--->
-<fieldType name="collated_da" class="solr.ICUCollationField" locale="da" strength="primary" caseLevel="false"/>
-<!--
   Danish Text Field unstemmed
   7.0.0
 -->
@@ -344,11 +314,6 @@
     <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
   </analyzer>
 </fieldType>
-<!--
-  Dutch Text Field collated
-  7.0.0
--->
-<fieldType name="collated_nl" class="solr.ICUCollationField" locale="nl" strength="primary" caseLevel="false"/>
 <!--
   Dutch Text Field unstemmed
   7.0.0
@@ -443,11 +408,6 @@
   </analyzer>
 </fieldType>
 <!--
-  English Text Field collated
-  7.0.0
--->
-<fieldType name="collated_en" class="solr.ICUCollationField" locale="en" strength="primary" caseLevel="false"/>
-<!--
   English Text Field unstemmed
   7.0.0
 -->
@@ -502,11 +462,6 @@
   </analyzer>
 </fieldType>
 <!--
-  Finnish Text Field collated
-  7.0.0
--->
-<fieldType name="collated_fi" class="solr.ICUCollationField" locale="fi" strength="primary" caseLevel="false"/>
-<!--
   Finnish Text Field unstemmed
   7.0.0
 -->
@@ -560,11 +515,6 @@
     <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
   </analyzer>
 </fieldType>
-<!--
-  French Text Field collated
-  7.0.0
--->
-<fieldType name="collated_fr" class="solr.ICUCollationField" locale="fr" strength="primary" caseLevel="false"/>
 <!--
   French Text Field unstemmed
   7.0.0
@@ -862,11 +812,6 @@
   </analyzer>
 </fieldType>
 <!--
-  German Text Field collated
-  7.0.0
--->
-<fieldType name="collated_de" class="solr.ICUCollationField" locale="de" strength="primary" caseLevel="false"/>
-<!--
   German Text Field unstemmed
   7.0.0
 -->
@@ -918,11 +863,6 @@
   </analyzer>
 </fieldType>
 <!--
-  Greek Text Field collated
-  7.0.0
--->
-<fieldType name="collated_el" class="solr.ICUCollationField" locale="el" strength="primary" caseLevel="false"/>
-<!--
   Greek Text Field unstemmed
   7.0.0
 -->
@@ -966,11 +906,6 @@
     <filter class="solr.HindiStemFilterFactory"/>
   </analyzer>
 </fieldType>
-<!--
-  Hindi Text Field collated
-  7.0.0
--->
-<fieldType name="collated_hi" class="solr.ICUCollationField" locale="hi" strength="primary" caseLevel="false"/>
 <!--
   Hindi Text Field unstemmed
   7.0.0
@@ -1016,11 +951,6 @@
     <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
   </analyzer>
 </fieldType>
-<!--
-  Hungarian Text Field collated
-  7.0.0
--->
-<fieldType name="collated_hu" class="solr.ICUCollationField" locale="hu" strength="primary" caseLevel="false"/>
 <!--
   Hungarian Text Field unstemmed
   7.0.0
@@ -1072,11 +1002,6 @@
     <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
   </analyzer>
 </fieldType>
-<!--
-  Indonesian Text Field collated
-  7.0.0
--->
-<fieldType name="collated_id" class="solr.ICUCollationField" locale="id" strength="primary" caseLevel="false"/>
 <!--
   Indonesian Text Field unstemmed
   7.0.0
@@ -1131,11 +1056,6 @@
   </analyzer>
 </fieldType>
 <!--
-  Irish/Gaelic Text Field collated
-  7.7.0
--->
-<fieldType name="collated_ga" class="solr.ICUCollationField" locale="ga" strength="primary" caseLevel="false"/>
-<!--
   Irish/Gaelic Text Field unstemmed
   7.7.0
 -->
@@ -1186,11 +1106,6 @@
     <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
   </analyzer>
 </fieldType>
-<!--
-  Italian Text Field collated
-  7.0.0
--->
-<fieldType name="collated_it" class="solr.ICUCollationField" locale="it" strength="primary" caseLevel="false"/>
 <!--
   Italian Text Field unstemmed
   7.0.0
@@ -1250,11 +1165,6 @@
     <filter class="solr.CJKWidthFilterFactory"/>
   </analyzer>
 </fieldType>
-<!--
-  Japanese Text Field collated
-  8.0.0
--->
-<fieldType name="collated_ja" class="solr.ICUCollationField" locale="ja" strength="primary" caseLevel="false"/>
 <!--
   Japanese Text Field unstemmed
   8.0.0
@@ -1316,11 +1226,6 @@
   </analyzer>
 </fieldType>
 <!--
-  Language Undefined Text Field collated
-  7.0.0
--->
-<fieldType name="collated_und" class="solr.ICUCollationField" locale="en" strength="primary" caseLevel="false"/>
-<!--
   Latvian Text Field
   7.0.0
 -->
@@ -1347,11 +1252,6 @@
     <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
   </analyzer>
 </fieldType>
-<!--
-  Latvian Text Field collated
-  7.0.0
--->
-<fieldType name="collated_lv" class="solr.ICUCollationField" locale="lv" strength="primary" caseLevel="false"/>
 <!--
   Latvian Text Field unstemmed
   7.0.0
@@ -1447,11 +1347,6 @@
   </analyzer>
 </fieldType>
 <!--
-  Norwegian Bokmal Text Field collated
-  7.0.0
--->
-<fieldType name="collated_nb" class="solr.ICUCollationField" locale="nb" strength="primary" caseLevel="false"/>
-<!--
   Norwegian Bokmal Text Field unstemmed
   7.0.0
 -->
@@ -1508,11 +1403,6 @@
   </analyzer>
 </fieldType>
 <!--
-  Norwegian Nynorsk Text Field collated
-  7.0.0
--->
-<fieldType name="collated_nn" class="solr.ICUCollationField" locale="nn" strength="primary" caseLevel="false"/>
-<!--
   Norwegian Nynorsk Text Field unstemmed
   7.0.0
 -->
@@ -1561,11 +1451,6 @@
   </analyzer>
 </fieldType>
 <!--
-  Persian Text Field collated
-  7.0.0
--->
-<fieldType name="collated_fa" class="solr.ICUCollationField" locale="fa" strength="primary" caseLevel="false"/>
-<!--
   Persian Text Field unstemmed
   7.0.0
 -->
@@ -1611,11 +1496,6 @@
     <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
   </analyzer>
 </fieldType>
-<!--
-  Polish Text Field collated
-  7.0.0
--->
-<fieldType name="collated_pl" class="solr.ICUCollationField" locale="pl" strength="primary" caseLevel="false"/>
 <!--
   Polish Text Field unstemmed
   7.0.0
@@ -1667,11 +1547,6 @@
   </analyzer>
 </fieldType>
 <!--
-  Portuguese, Brazilian Text Field collated
-  7.0.0
--->
-<fieldType name="collated_pt_br" class="solr.ICUCollationField" locale="pt" strength="primary" caseLevel="false"/>
-<!--
   Portuguese, Brazilian Text Field unstemmed
   7.0.0
 -->
@@ -1719,11 +1594,6 @@
     <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
   </analyzer>
 </fieldType>
-<!--
-  Portuguese, Portugal Text Field collated
-  7.0.0
--->
-<fieldType name="collated_pt_pt" class="solr.ICUCollationField" locale="pt" strength="primary" caseLevel="false"/>
 <!--
   Portuguese, Portugal Text Field unstemmed
   7.0.0
@@ -1773,11 +1643,6 @@
   </analyzer>
 </fieldType>
 <!--
-  Romanian Text Field collated
-  7.0.0
--->
-<fieldType name="collated_ro" class="solr.ICUCollationField" locale="ro" strength="primary" caseLevel="false"/>
-<!--
   Romanian Text Field unstemmed
   7.0.0
 -->
@@ -1823,11 +1688,6 @@
     <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
   </analyzer>
 </fieldType>
-<!--
-  Russian Text Field collated
-  7.0.0
--->
-<fieldType name="collated_ru" class="solr.ICUCollationField" locale="ru" strength="primary" caseLevel="false"/>
 <!--
   Russian Text Field unstemmed
   7.0.0
@@ -1877,11 +1737,6 @@
     <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
   </analyzer>
 </fieldType>
-<!--
-  Serbian Text Field collated
-  7.0.0
--->
-<fieldType name="collated_sr" class="solr.ICUCollationField" locale="sr" strength="primary" caseLevel="false"/>
 <!--
   Serbian Text Field unstemmed
   7.0.0
@@ -1940,11 +1795,6 @@
   </analyzer>
 </fieldType>
 <!--
-  Simplified Chinese Text Field collated
-  7.0.0
--->
-<fieldType name="collated_zh_hans" class="solr.ICUCollationField" locale="zh" strength="primary" caseLevel="false"/>
-<!--
   Simplified Chinese Text Field unstemmed
   7.0.0
 -->
@@ -1988,11 +1838,6 @@
     <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
   </analyzer>
 </fieldType>
-<!--
-  Slovak Text Field collated
-  7.0.0
--->
-<fieldType name="collated_sk" class="solr.ICUCollationField" locale="sk" strength="primary" caseLevel="false"/>
 <!--
   Slovak Text Field unstemmed
   7.0.0
@@ -2042,11 +1887,6 @@
     <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
   </analyzer>
 </fieldType>
-<!--
-  Spanish Text Field collated
-  7.0.0
--->
-<fieldType name="collated_es" class="solr.ICUCollationField" locale="es" strength="primary" caseLevel="false"/>
 <!--
   Spanish Text Field unstemmed
   7.0.0
@@ -2099,11 +1939,6 @@
     <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
   </analyzer>
 </fieldType>
-<!--
-  Swedish Text Field collated
-  7.0.0
--->
-<fieldType name="collated_sv" class="solr.ICUCollationField" locale="no" strength="primary" caseLevel="false"/>
 <!--
   Swedish Text Field unstemmed
   7.0.0
@@ -2161,11 +1996,6 @@
   </analyzer>
 </fieldType>
 <!--
-  Thai Text Field collated
-  7.0.0
--->
-<fieldType name="collated_th" class="solr.ICUCollationField" locale="th" strength="primary" caseLevel="false"/>
-<!--
   Traditional Chinese Text Field
   7.0.0
 -->
@@ -2195,11 +2025,6 @@
     <filter class="solr.LowerCaseFilterFactory"/>
   </analyzer>
 </fieldType>
-<!--
-  Traditional Chinese Text Field collated
-  7.0.0
--->
-<fieldType name="collated_zh_hant" class="solr.ICUCollationField" locale="zh-hant" strength="primary" caseLevel="false"/>
 <!--
   Turkish Text Field
   7.0.0
@@ -2240,11 +2065,6 @@
     <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
   </analyzer>
 </fieldType>
-<!--
-  Turkish Text Field collated
-  7.0.0
--->
-<fieldType name="collated_tr" class="solr.ICUCollationField" locale="tr" strength="primary" caseLevel="false"/>
 <!--
   Turkish Text Field unstemmed
   7.0.0
@@ -2293,11 +2113,6 @@
     <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
   </analyzer>
 </fieldType>
-<!--
-  Ukrainian Text Field collated
-  7.0.0
--->
-<fieldType name="collated_uk" class="solr.ICUCollationField" locale="uk" strength="primary" caseLevel="false"/>
 <!--
   Ukrainian Text Field unstemmed
   7.0.0


### PR DESCRIPTION
Using search_api_solr 4.2.3:

When generating a solr core with solr version 8.11 I got this error:

```
solr@solr:/opt/solr-8.11.2$ bin/solr create_core -c solr_core_811 -d solr811 -n solr811

ERROR: Error CREATEing SolrCore 'solr_core_811': Unable to create core [solr_core_811] Caused by: solr.ICUCollationField
```

The config set I was using was generated with 

`drush solr-gsc solr_search_server solr811_drush.zip 8.11`

The config set was successfully generated but I had to take out all the collated_en fields and then solr with drupal+drush was usable.

The solr image (and version) I am using is  ( arm64v8/solr:8 ) ( https://github.com/docker-solr/docker-solr/blob/970bb718583d14f6f1300f6fd261f01ddcf757c8/8.11/Dockerfile )   ( https://hub.docker.com/r/arm64v8/solr/#! ) 


This patch & change should take that field out for all the jump-start config-sets.  However I did not change the cloud templates.
