### PR TITLE
3298207: Broaden drush services version constraint for Drush 11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,7 @@
     "extra": {
         "drush": {
             "services": {
-                "drush.services.yml": "^9 || ^10"
+                "drush.services.yml": ">=9"
             }
         }
     }


### PR DESCRIPTION
For sites updating to latest stable major release of drush 11 one will see the following debug output.

<code>[debug] search_api_solr commands loaded even though its constraint (^9 || ^10) is incompatible with Drush 11.x. Broaden the constraint in modules/contrib/search_api_solr/composer.json (see 'extra\drush\services' section) to remove this message.</code>

Update the constraint syntax within the composer.json file as indicated.