### PR TITLE
Issue #3314863 on drupal.org

### DIFF
--- a/src/Event/PreAddLanguageFallbackFieldEvent.php
+++ b/src/Event/PreAddLanguageFallbackFieldEvent.php
@@ -53,7 +53,7 @@ final class PreAddLanguageFallbackFieldEvent extends Event {
    * @param \Drupal\search_api\Item\ItemInterface $item
    *   The Search API item the field belongs to.
    */
-  public function __construct(string $langcode, mixed $value, string $type, ItemInterface $item) {
+  public function __construct(string $langcode, $value, string $type, ItemInterface $item) {
     $this->langcode = $langcode;
     $this->value = $value;
     $this->type = $type;
@@ -76,7 +76,7 @@ final class PreAddLanguageFallbackFieldEvent extends Event {
    * @return mixed
    *   The field values.
    */
-  public function getValue(): mixed {
+  public function getValue() {
     return $this->value;
   }
 
@@ -87,7 +87,7 @@ final class PreAddLanguageFallbackFieldEvent extends Event {
    *   The field value. If you supply NULL as the value and no modifier the
    *   field will be removed.
    */
-  public function setValue(mixed $value): void {
+  public function setValue($value): void {
     $this->value = $value;
   }
 


### PR DESCRIPTION
PHP 7 incompatibility - TypeError: Argument 2 passed to Drupal\search_api_solr\Event\PreAddLanguageFallbackFieldEvent::__construct() must be an instance of Drupal\search_api_solr\Event\mixed, array given

This removes the 'mixed' typehint to keep the code compatible with PHP 7.4: https://php.watch/versions/8.0/mixed-type