### PR TITLE
Mention Search API Solr module and minimum version in outdated config files message

### DIFF
--- a/src/Plugin/search_api/backend/SearchApiSolrBackend.php
+++ b/src/Plugin/search_api/backend/SearchApiSolrBackend.php
@@ -946,7 +946,7 @@ class SearchApiSolrBackend extends BackendPluginBase implements SolrBackendInter
                   $variables[':min_version'] = SolrBackendInterface::SEARCH_API_SOLR_MIN_SCHEMA_VERSION;
                   if (preg_match('/^drupal-(.*?)-solr/', $stats_summary['@schema_version'], $matches)) {
                     if (Comparator::lessThan($matches[1], SolrBackendInterface::SEARCH_API_SOLR_MIN_SCHEMA_VERSION)) {
-                      $this->messenger->addError($this->t('Solr is using an outdated <a href="https://solr.apache.org/guide/solr/latest/configuration-guide/config-sets.html">configset</a>, created with a version of Search API Solr older than :min_version. Please follow the instructions in the <a href=":url">README.md</a> file, to create and deploy a fresh set of Solr config files, based on the currently installed version of Search API Solr.', $variables));
+                      $this->messenger->addError($this->t('Solr is using an outdated <a href="https://solr.apache.org/guide/solr/latest/configuration-guide/config-sets.html">configset</a>, created with a version of Search API Solr older than :min_version. Please follow the instructions in the <a href=":url">README.md</a> file, to create and deploy a fresh set of Solr configuration files, based on the currently installed version of Search API Solr.', $variables));
                       $status = 'error';
                     }
                   }

--- a/src/Plugin/search_api/backend/SearchApiSolrBackend.php
+++ b/src/Plugin/search_api/backend/SearchApiSolrBackend.php
@@ -946,7 +946,7 @@ class SearchApiSolrBackend extends BackendPluginBase implements SolrBackendInter
                   $variables[':min_version'] = SolrBackendInterface::SEARCH_API_SOLR_MIN_SCHEMA_VERSION;
                   if (preg_match('/^drupal-(.*?)-solr/', $stats_summary['@schema_version'], $matches)) {
                     if (Comparator::lessThan($matches[1], SolrBackendInterface::SEARCH_API_SOLR_MIN_SCHEMA_VERSION)) {
-                      $this->messenger->addError($this->t('Solr is using outdated config files from Search API Solr :min_version or before. Please follow the instructions in the <a href=":url">README.md</a> file on how to update Solr config files.', $variables));
+                      $this->messenger->addError($this->t('Solr is using outdated config files. Please update to at least Search API Solr :min_version, and follow the instructions in the <a href=":url">README.md</a> file on how to update Solr config files.', $variables));
                       $status = 'error';
                     }
                   }

--- a/src/Plugin/search_api/backend/SearchApiSolrBackend.php
+++ b/src/Plugin/search_api/backend/SearchApiSolrBackend.php
@@ -940,13 +940,13 @@ class SearchApiSolrBackend extends BackendPluginBase implements SolrBackendInter
                   'label' => $this->t('%key: Delay', ['%key' => $key]),
                   'info' => $this->t('@autocommit_time before updates are processed.', $stats_summary),
                 ];
-
                 $status = 'ok';
                 if (!$this->isNonDrupalOrOutdatedConfigSetAllowed()) {
                   $variables[':url'] = Url::fromUri('internal:/' . $this->moduleExtensionList->getPath('search_api_solr') . '/README.md')->toString();
+                  $variables[':min_version'] = SolrBackendInterface::SEARCH_API_SOLR_MIN_SCHEMA_VERSION;
                   if (preg_match('/^drupal-(.*?)-solr/', $stats_summary['@schema_version'], $matches)) {
                     if (Comparator::lessThan($matches[1], SolrBackendInterface::SEARCH_API_SOLR_MIN_SCHEMA_VERSION)) {
-                      $this->messenger->addError($this->t('You are using outdated Solr configuration set. Please follow the instructions described in the <a href=":url">README.md</a> file for setting up Solr.', $variables));
+                      $this->messenger->addError($this->t('Solr is using outdated config files from Search API Solr :min_version or before. Please follow the instructions in the <a href=":url">README.md</a> file on how to to update Solr config files.', $variables));
                       $status = 'error';
                     }
                   }

--- a/src/Plugin/search_api/backend/SearchApiSolrBackend.php
+++ b/src/Plugin/search_api/backend/SearchApiSolrBackend.php
@@ -946,7 +946,7 @@ class SearchApiSolrBackend extends BackendPluginBase implements SolrBackendInter
                   $variables[':min_version'] = SolrBackendInterface::SEARCH_API_SOLR_MIN_SCHEMA_VERSION;
                   if (preg_match('/^drupal-(.*?)-solr/', $stats_summary['@schema_version'], $matches)) {
                     if (Comparator::lessThan($matches[1], SolrBackendInterface::SEARCH_API_SOLR_MIN_SCHEMA_VERSION)) {
-                      $this->messenger->addError($this->t('Solr is using outdated config files from Search API Solr :min_version or before. Please follow the instructions in the <a href=":url">README.md</a> file on how to to update Solr config files.', $variables));
+                      $this->messenger->addError($this->t('Solr is using outdated config files from Search API Solr :min_version or before. Please follow the instructions in the <a href=":url">README.md</a> file on how to update Solr config files.', $variables));
                       $status = 'error';
                     }
                   }

--- a/src/Plugin/search_api/backend/SearchApiSolrBackend.php
+++ b/src/Plugin/search_api/backend/SearchApiSolrBackend.php
@@ -946,7 +946,7 @@ class SearchApiSolrBackend extends BackendPluginBase implements SolrBackendInter
                   $variables[':min_version'] = SolrBackendInterface::SEARCH_API_SOLR_MIN_SCHEMA_VERSION;
                   if (preg_match('/^drupal-(.*?)-solr/', $stats_summary['@schema_version'], $matches)) {
                     if (Comparator::lessThan($matches[1], SolrBackendInterface::SEARCH_API_SOLR_MIN_SCHEMA_VERSION)) {
-                      $this->messenger->addError($this->t('Solr is using outdated config files. Please update to at least Search API Solr :min_version, and follow the instructions in the <a href=":url">README.md</a> file on how to update Solr config files.', $variables));
+                      $this->messenger->addError($this->t('Solr is using an outdated <a href="https://solr.apache.org/guide/solr/latest/configuration-guide/config-sets.html">configset</a>, created with a version of Search API Solr older than :min_version. Please follow the instructions in the <a href=":url">README.md</a> file, to create and deploy a fresh set of Solr config files, based on the currently installed version of Search API Solr.', $variables));
                       $status = 'error';
                     }
                   }


### PR DESCRIPTION
The error message when using outdated config files is not clear enough, and some users fail to understand what the message means. See for example https://github.com/ddev/ddev-drupal9-solr/issues/15.

Let's add some details, such as mentioning the Search API Solr module and version number, to make it clearer.

### Now 
> **Error message**
> You are using outdated Solr configuration set. Please follow the instructions described in the [README.md](https://d10solr.ddev.site/modules/contrib/search_api_solr/README.md) file for setting up Solr.

### Proposal
> **Error message**
> Solr is using outdated config files from Search API Solr 4.2.8 or before. Please follow the instructions in the [README.md](https://d10solr.ddev.site/modules/contrib/search_api_solr/README.md) file on how to to update Solr config files.