### PR TITLE
Reduce aliases

### DIFF
--- a/src/Commands/SearchApiSolrCommands.php
+++ b/src/Commands/SearchApiSolrCommands.php
@@ -53,7 +53,7 @@ class SearchApiSolrCommands extends DrushCommands implements StdinAwareInterface
    * @usage drush search-api-solr:reinstall-fieldtypes
    *   Deletes all Solr Field Type and re-installs them from their yml files.
    *
-   * @aliases solr-reinstall-ft,sasm-reinstall-ft,search-api-solr-delete-and-reinstall-all-field-types,search-api-solr-multilingual-delete-and-reinstall-all-field-types
+   * @aliases solr-reinstall-ft
    */
   public function reinstallFieldtypes() {
     $this->commandHelper->reinstallFieldtypesCommand();
@@ -91,7 +91,7 @@ class SearchApiSolrCommands extends DrushCommands implements StdinAwareInterface
    * @usage drush search-api-solr:get-server-config server_id file_name
    *   Get the config files for a solr server and save it as zip file.
    *
-   * @aliases solr-gsc,sasm-gsc,search-api-solr-get-server-config,search-api-solr-multilingual-get-server-config
+   * @aliases solr-gsc
    *
    * @throws \Drupal\search_api\ConsoleException
    * @throws \Drupal\search_api\SearchApiException


### PR DESCRIPTION
## Problem

Having a lot of aliases clogs up the list of Drush commands. See also https://github.com/drush-ops/drush/issues/5681.

## Solution

Reduce the number of aliases.

### Before


```
search-api-solr:
  search-api-solr:execute-raw-streaming-expression (solr-erse)                Executes a streaming expression from STDIN.
  search-api-solr:finalize-index (solr-finalize)                              Indexes items for one or all enabled search 
                                                                              indexes.
  search-api-solr:get-server-config (solr-gsc, sasm-gsc,                      Gets the config for a Solr search server.
search-api-solr-multilingual-get-server-config)
  search-api-solr:install-missing-fieldtypes                                  Install missing Solr Field Types from their yml 
                                                                              files.
  search-api-solr:reinstall-fieldtypes (solr-reinstall-ft, sasm-reinstall-ft, Re-install Solr Field Types from their yml 
search-api-solr-delete-and-reinstall-all-field-types,                         files.
search-api-solr-multilingual-delete-and-reinstall-all-field-types)

```

### After

```
search-api-solr:
  search-api-solr:execute-raw-streaming-expression         Executes a streaming expression from STDIN.
(solr-erse)
  search-api-solr:finalize-index (solr-finalize)           Indexes items for one or all enabled search indexes.
  search-api-solr:get-server-config (solr-gsc)             Gets the config for a Solr search server.
  search-api-solr:install-missing-fieldtypes               Install missing Solr Field Types from their yml files.
  search-api-solr:reinstall-fieldtypes (solr-reinstall-ft) Re-install Solr Field Types from their yml files.

```