### PR TITLE
Issue #3402831: [sorting] Always set the multivalue's first value as long as it's not NULL

### DIFF
--- a/src/Plugin/search_api/backend/SearchApiSolrBackend.php
+++ b/src/Plugin/search_api/backend/SearchApiSolrBackend.php
@@ -1381,7 +1381,7 @@ class SearchApiSolrBackend extends BackendPluginBase implements SolrBackendInter
         }
 
         // Enable sorts in some special cases.
-        if ($first_value && !array_key_exists($name, $special_fields)) {
+        if (($first_value !== NULL) && !array_key_exists($name, $special_fields)) {
           if (
             strpos($field_names[$name], 't') === 0 ||
             strpos($field_names[$name], 's') === 0
@@ -2647,11 +2647,11 @@ class SearchApiSolrBackend extends BackendPluginBase implements SolrBackendInter
     if (empty($values)) {
       if ('text' !== $type || !$this->configuration['index_empty_text_fields']) {
         // Don't index empty values (i.e., when field is missing).
-        return '';
+        return NULL;
       }
     }
 
-    $first_value = '';
+    $first_value = NULL;
 
     // All fields.
     foreach ($values as $value) {


### PR DESCRIPTION
Original upstream issue: https://www.drupal.org/project/search_api_solr/issues/3402831

I have a list item that stores the value `[0]`, however this means the first value resolves to `0`, which means its skipped entirely and not added as a singular value since it's "empty".

We should change the logic to be more explicit, such that it only adds field values if they're not NULL, rather than check if they're empty.