### PR TITLE
Support passing facet prefix, contains, and contians.ignoreCase to Solarium library setPrefix method

### DIFF
--- a/src/Plugin/search_api/backend/SearchApiSolrBackend.php
+++ b/src/Plugin/search_api/backend/SearchApiSolrBackend.php
@@ -3843,8 +3843,16 @@ class SearchApiSolrBackend extends BackendPluginBase implements SolrBackendInter
             $facet_field->setMissing(FALSE);
           }
 
-          if ($info['prefix']) {
+          if (isset($info['prefix'])) {
             $facet_field->setPrefix($info['prefix']);
+          }
+
+          if (isset($info['contains'])) {
+            $facet_field->setContains($info['contains']);
+          }
+
+          if (isset($info['contains.ignoreCase'])) {
+            $facet_field->setContainsIgnoreCase($info['contains.ignoreCase']);
           }
       }
 

--- a/src/Plugin/search_api/backend/SearchApiSolrBackend.php
+++ b/src/Plugin/search_api/backend/SearchApiSolrBackend.php
@@ -3842,6 +3842,10 @@ class SearchApiSolrBackend extends BackendPluginBase implements SolrBackendInter
           else {
             $facet_field->setMissing(FALSE);
           }
+
+          if ($info['prefix']) {
+            $facet_field->setPrefix($info['prefix']);
+          }
       }
 
       // For "OR" facets, add the expected tag for exclusion.


### PR DESCRIPTION
https://www.drupal.org/project/search_api_solr/issues/3482328

Solr has a facet.prefix option that can be used to filter the facet options ("constraints") that are returned, based on the first characters of a field's indexed value. This is handy for building autocomplete fields for facets that have too many options to list all at once.

The search_api_solr module just needs to check if a developer has passed a prefix in to the facet options and then call the Solarium library's setPrefix() method accordingly.

UPDATE: Also added support for Solr's facet.contains and facet.containsIgnore options.