### PR TITLE
fix: #2943668 Duplicate suggestions not correctly filtered from autocomplete, use AND operator

### DIFF
--- a/src/SolrAutocompleteBackendTrait.php
+++ b/src/SolrAutocompleteBackendTrait.php
@@ -53,7 +53,7 @@ trait SolrAutocompleteBackendTrait {
     /** @var \Drupal\search_api_autocomplete\Suggestion\SuggestionInterface $suggestion */
     foreach ($suggestions as $key => $suggestion) {
       if (
-        !in_array($suggestion->getSuggestedKeys(), $added_suggestions, TRUE) ||
+        !in_array($suggestion->getSuggestedKeys(), $added_suggestions, TRUE) &&
         !in_array($suggestion->getUrl(), $added_urls, TRUE)
       ) {
         $added_suggestions[] = $suggestion->getSuggestedKeys();


### PR DESCRIPTION
I thing that the `||` operator is wrong on `filterDuplicateAutocompleteSuggestions()` method. The corect is `&&`.

Related issue but for 2.x version: https://www.drupal.org/project/search_api_solr/issues/2943668 