### PR TITLE
Issue #3584036: Implement SolrConnectorPluginBase::__destruct to remove Solarium plugin listeners from the event dispatcher.

### DIFF
--- a/src/SolrConnector/SolrConnectorPluginBase.php
+++ b/src/SolrConnector/SolrConnectorPluginBase.php
@@ -1390,4 +1390,15 @@ abstract class SolrConnectorPluginBase extends ConfigurablePluginBase implements
   public function alterConfigZip(ZipStream $zip, string $lucene_match_version, string $server_id = '') {
   }
 
+  /**
+   * Removes Solarium plugin listeners from the shared event dispatcher.
+   */
+  public function __destruct() {
+    if ($this->solr) {
+      foreach ($this->solr->getPlugins() as $plugin) {
+        $this->solr->removePlugin($plugin);
+      }
+    }
+  }
+
 }


### PR DESCRIPTION
https://www.drupal.org/project/search_api_solr/issues/3584036